### PR TITLE
Fix problems with INVALID IPN calls when parsing addresses containing quotes

### DIFF
--- a/dgx-donate-paypalstd-ipn.php
+++ b/dgx-donate-paypalstd-ipn.php
@@ -91,17 +91,27 @@ class Dgx_Donate_IPN_Handler {
 	}
 
 	function reply_to_paypal() {
-		$req = 'cmd=_notify-validate';
-		$get_magic_quotes_exists = function_exists( 'get_magic_quotes_gpc' );
-
-		foreach ($_POST as $key => $value) {
-			if( $get_magic_quotes_exists && get_magic_quotes_gpc() == 1 ) {
-				$value = urlencode( stripslashes( $value ) );
-			} else {
-				$value = urlencode( $value );
-			}
-			$req .= "&$key=$value";
-		}
+    $raw_post_data = file_get_contents('php://input');
+    $raw_post_array = explode('&', $raw_post_data);
+    $myPost = array();
+    foreach ($raw_post_array as $keyval) {
+	    $keyval = explode ('=', $keyval);
+	    if (count($keyval) == 2)
+	    	$myPost[$keyval[0]] = urldecode($keyval[1]);
+    }
+    // read the IPN message sent from PayPal and prepend 'cmd=_notify-validate'
+    $req = 'cmd=_notify-validate';
+    if(function_exists('get_magic_quotes_gpc')) {
+      $get_magic_quotes_exists = true;
+    }
+    foreach ($myPost as $key => $value) {
+    	if($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
+    		$value = urlencode(stripslashes($value));
+    	} else {
+    		$value = urlencode($value);
+    	}
+    	$req .= "&$key=$value";
+    }
 
 		$header = "POST /cgi-bin/webscr HTTP/1.0\r\n";
 		$header .= $this->host_header;
@@ -120,7 +130,6 @@ class Dgx_Donate_IPN_Handler {
 					$done = true;
 				} else {
 					$response = fgets( $fp, 1024 );
-					dgx_donate_debug_log( print_r($response,true) );
 					$done = in_array( $response, array( "VERIFIED", "INVALID" ) );
 				}
 			} while ( ! $done );


### PR DESCRIPTION
Hi Rasmus,

I found a way to reproduce our "INVALID" IPN issues. I changed the address of one of my Sandbox users to contain quotes, something like `Rue 'Invented 8`. Then I subscribed with this user and I could see the "INVALID" IPN issue in my local logs.

With this information, I searched for a solution and went back to Paypal's official documentation. It turns out that Seamless Donations implementation of the IPN is not updated. The Paypal docs have a note saying that serialization issues can occur if you use `$_POST` instead of `php://input` with Paypal. So I just copied their example, replaced the old code... and it works! No more INVALID errors.

We'll have to test it in production during some time to be completely sure, but I think we are in the right track.

Warm regards,
Ignacio
