### PR TITLE
Remove limit on JOINs for Cron job

### DIFF
--- a/dgx-donate-cron-jobs.php
+++ b/dgx-donate-cron-jobs.php
@@ -22,6 +22,7 @@
   function minimum_donations_notification() {
     global $wpdb;
 
+    $wpdb->get_results("SET SQL_BIG_SELECTS=1;");
     $supporters_to_be_downgraded = $wpdb->get_results(
       "
       SELECT display_name, email, amount FROM (


### PR DESCRIPTION
Hi Rasmus,

I have found the source of why the query was not working: there are so many users in the database, and the JOINs are so big that we were hitting a Mysql limit. As a workaround, we can disable the limit for the query. 

Running it in phpmyadmin seems to work, but I'm not sure if it will work within WordPress. Could you upload this change and see if it works? It should send an email with 888 users.

Warm regards,
Ignacio
