### PR TITLE
Exclude users paying through bank transfer from monthly check

### DIFF
--- a/dgx-donate-cron-jobs.php
+++ b/dgx-donate-cron-jobs.php
@@ -46,9 +46,14 @@
         LEFT JOIN ".$wpdb->prefix."postmeta m3 ON posts.id = m3.post_id AND m3.meta_key = '_dgx_donate_amount'
         # And the currency
         LEFT JOIN ".$wpdb->prefix."postmeta m4 ON posts.id = m4.post_id AND m4.meta_key = '_dgx_donate_donation_currency'
+        # Join the usermeta again to check the donation method
+        LEFT JOIN sbc1_usermeta m5 ON users.ID = m5.user_id AND m5.meta_key = 'donation_method'
 
         # Only users with role 'supporter'
         WHERE m1.meta_key = '".$wpdb->prefix."capabilities' AND m1.meta_value LIKE \"%upporter%\"
+
+        # And exclude users who pay through the bank
+        AND (m5.meta_value IS NULL || m5.meta_value != 'Bank')
 
         GROUP BY users.id
 


### PR DESCRIPTION
Hi Rasmus,

I have added a field to the user's profile (using UPME custom fields, only visible and editable by admins):

![captura de pantalla de 2014-08-28 15 50 50](https://cloud.githubusercontent.com/assets/452823/4076477/74d298e2-2eba-11e4-89bb-7f5ac80335ac.png)

If it is set to "Bank", then the user is excluded from the monthly check. I suppose there are a lot of bank users, and editing all of them is going to be a pain. Maybe we need something to automatise this?

Regards,
Ignacio
